### PR TITLE
Error management Flutter side and manage more barcode format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.3
+
+- Bug fix : BarcodeScanner onError callback is never called
+- Bug fix : iOS missing Codabar format
+- Support format upca/upce for Android
+- Support format upce for iOS (upca is not available)
+
 ## 1.0.2
 
 - Bug fix : update iOS .podspec file

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ Even for devices with an older version than Android 10 (where `PlatformViews` in
 | :-----: | :-----: |
 |   ✅    |   ✅    |
 
+## Barcode format Supported
+
+|   Format   | Android |  iOS    |
+|:----------:|:-------:| :-----: |
+|  CODE-39   |    ✅    |   ✅    |
+|  CODE-93   |    ✅    |   ✅    |
+|  CODE-128  |    ✅    |   ✅    |
+|   EAN-8    |    ✅    |   ✅    |
+|   EAN-13   |    ✅    |   ✅    |
+|    ITF     |    ✅    |   ✅    |
+|  Codabar   |    ✅    |   ✅    |
+| DataMatrix |    ✅    |   ✅    |
+|   QRCode   |    ✅    |   ✅    |
+|   UPC-A    |    ✅    |   ❌    |
+|   UPC-E    |    ✅    |   ✅    |
+
 ## Getting Started
 
 Add this to your package's `pubspec.yaml` file:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,9 @@ group 'be.freedelity.barcode_scanner'
 version '1.0-SNAPSHOT'
 
 buildscript {
+
+    ext.kotlin_version = '1.6.10'
+
     repositories {
         google()
         mavenCentral()

--- a/android/src/main/kotlin/be/freedelity/barcode_scanner/Constants.kt
+++ b/android/src/main/kotlin/be/freedelity/barcode_scanner/Constants.kt
@@ -19,4 +19,6 @@ object BarcodeFormats {
     const val CODABAR : Int = 6;
     const val DATAMATRIX : Int = 7;
     const val QR_CODE : Int = 8;
+    const val UPCA_A : Int = 9;
+    const val UPC_E : Int = 10;
 }

--- a/ios/Classes/Constants.swift
+++ b/ios/Classes/Constants.swift
@@ -19,4 +19,5 @@ struct BarcodeFormats {
     static let CODABAR: Int = 6
     static let DATAMATRIX: Int = 7
     static let QR_CODE: Int = 8
+    static let UPC_E: Int = 10
 }

--- a/lib/barcode_scanner.dart
+++ b/lib/barcode_scanner.dart
@@ -18,7 +18,9 @@ enum BarcodeFormat {
   itf,
   codabar,
   dataMatrix,
-  qrCode;
+  qrCode,
+  upca,
+  upce;
 
   /// @nodoc
   static BarcodeFormat? unserialize(int constant) {
@@ -41,6 +43,10 @@ enum BarcodeFormat {
         return BarcodeFormat.dataMatrix;
       case _formatQrCode:
         return BarcodeFormat.qrCode;
+      case _formatUpca:
+        return BarcodeFormat.upca;
+      case _formatUpce:
+        return BarcodeFormat.upce;
       default:
         return null;
     }
@@ -91,3 +97,5 @@ const int _formatItf = 5;
 const int _formatCodabar = 6;
 const int _formatDataMatrix = 7;
 const int _formatQrCode = 8;
+const int _formatUpca = 9;
+const int _formatUpce = 10;


### PR DESCRIPTION
- [x] Bug fix : onError event from Flutter side which is supposed to be called from EventHandler when an error occurs from native platform is never triggered
- [x] Missing **codebar** format which should be supported from iOS 
- [x] Add more supported format upca/upce for Android and upce for iOS
- [x] Add supported format to README
- [x] Bug fix : Related to #2 , the format value on iOS should not be null on barcode detected