### PR TITLE
bump version of podspec to 1.0.4

### DIFF
--- a/ios/native_barcode_scanner.podspec
+++ b/ios/native_barcode_scanner.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'native_barcode_scanner'
-  s.version          = '1.0.1'
+  s.version          = '1.0.4'
   s.summary          = 'Barcode scanner plugin'
   s.description      = <<-DESC
 Barcode scanner plugin


### PR DESCRIPTION
Updating the version defined in podspec to indicate there was a change in the native code for iOS so that cocoapod won't keep in cache an outdated pod.

Fixes #8 