### PR TITLE
Fix race condition where event is received while not mounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next release
+
+- Bug fix: barcode event could be sent after the widget has been detached from the widget tree.
+
 ## 1.0.8
 
 - Bug fix : the iOS default permission request never start the camera even when agreed

--- a/lib/barcode_scanner.widget.dart
+++ b/lib/barcode_scanner.widget.dart
@@ -1,7 +1,7 @@
 // Copyright 2023 Freedelity. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -59,6 +59,7 @@ class _BarcodeScannerWidgetState extends State<BarcodeScannerWidget> {
   EventChannel('be.freedelity/native_scanner/imageStream');
 
   late Map<String, dynamic> creationParams;
+  late StreamSubscription eventSubscription;
 
   @override
   void initState() {
@@ -71,7 +72,7 @@ class _BarcodeScannerWidgetState extends State<BarcodeScannerWidget> {
       'start_scanning': widget.startScanning,
     };
 
-    eventChannel.receiveBroadcastStream().listen((dynamic event) async {
+    eventSubscription = eventChannel.receiveBroadcastStream().listen((dynamic event) async {
       if (widget.onBarcodeDetected != null && widget.scannerType == ScannerType.barcode) {
         final format = BarcodeFormat.unserialize(event['format']);
         if (format != null) {
@@ -94,6 +95,12 @@ class _BarcodeScannerWidgetState extends State<BarcodeScannerWidget> {
     }, onError: (dynamic error) {
       widget.onError(error);
     });
+  }
+
+  @override
+  void dispose() {
+    eventSubscription.cancel();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
There is a race condition that may call `onBarcodeDetected` while the widget is not mounted anymore.

The event channel stream listener was not canceled and outlived the widget. In most situations, the platform view will promptly stop the barcode scanning when detached but it may occur that a barcode event is sent after the widget is unmounted.

This ensures that the stream subscription is canceled when disposing `_BarcodeScannerWidgetState`