### PR TITLE
Fix android camera already in use error

### DIFF
--- a/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerController.kt
+++ b/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerController.kt
@@ -125,6 +125,16 @@ class BarcodeScannerController(private val activity: Activity, messenger: Binary
                         handleException(e, result)
                     }
                 }
+                "closeCamera" -> {
+                    try {
+                        val cameraProvider = ProcessCameraProvider.getInstance(context).get()
+                        cameraProvider.unbindAll()
+
+                        result.success(null)
+                    } catch (e: Exception) {
+                        handleException(e, result)
+                    }
+                }
                 else -> result.notImplemented()
             }
 

--- a/lib/barcode_scanner.dart
+++ b/lib/barcode_scanner.dart
@@ -90,6 +90,9 @@ abstract class BarcodeScanner {
 
   /// Start the scanning process. It is useful in case `BarcodeScanner.stopScanner` has been called before or if `BarcodeScannerWidget` has been created with `startScanning` set to `false`.
   static Future startScanner() => _channel.invokeMethod('startScanner');
+
+  /// Close Android camera manually.
+  static Future closeCamera() => _channel.invokeMethod('closeCamera');
 }
 
 // Constants for serializing barcode formats in event channel

--- a/lib/barcode_scanner.widget.dart
+++ b/lib/barcode_scanner.widget.dart
@@ -100,6 +100,7 @@ class _BarcodeScannerWidgetState extends State<BarcodeScannerWidget> {
   @override
   void dispose() {
     eventSubscription.cancel();
+    BarcodeScanner.closeCamera();
     super.dispose();
   }
 


### PR DESCRIPTION
Hello!
I'm Dan Lee, a lead developer from South Korea.

While using your library, I encountered an error in the Android environment stating that the camera was already in use when trying to load the camera preview on a different screen. This issue was not present in the iOS environment.

Upon investigation, I discovered that even after cancelling the event subscription with cancel(), the camera remained open at the native level, preventing its use on other screens.

To resolve this error, I added a method to manually unbind the camera in the Android environment within the library source code and called it during dispose(). Other way, Adding this into cancel() method might be good also.

Thank you for developing such an excellent library.