### PR TITLE
define closeCamera channel method for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Bug fix : Android camera already in use after close, preventing its use on other screens
 - Bug fix : barcode event could be sent after the widget has been detached from the widget tree.
+- Bug fix : Fix Android supported version to 1.8
+- Bug fix : Define close camera channel method for iOS
 
 ## 1.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
+## Pending
+- Bug fix : Fix Android supported version to 1.8
+- Bug fix : Define close camera channel method for iOS
+
 ## 1.0.9
 
 - Bug fix : Android camera already in use after close, preventing its use on other screens
 - Bug fix : barcode event could be sent after the widget has been detached from the widget tree.
-- Bug fix : Fix Android supported version to 1.8
-- Bug fix : Define close camera channel method for iOS
 
 ## 1.0.8
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,16 +26,13 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 }
 
-enum CameraActions {
-  flipCamera,
-  toggleFlashlight,
-  stopScanner,
-  startScanner,
-  setOverlay
-}
+enum CameraActions { flipCamera, toggleFlashlight, stopScanner, startScanner, setOverlay, navigate }
 
 class _MyAppState extends State<MyApp> {
-  bool withOverlay = true;
+  @override
+  void dispose() {
+    super.dispose();
+  }
 
   @override
   void initState() {
@@ -44,144 +41,152 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-        home: Scaffold(
-            appBar: AppBar(
-                title: const Text('Scanner plugin example app'),
-                actions: [
-                  PopupMenuButton<CameraActions>(
-                    onSelected: (CameraActions result) {
-                      switch (result) {
-                        case CameraActions.flipCamera:
-                          BarcodeScanner.flipCamera();
-                          break;
-                        case CameraActions.toggleFlashlight:
-                          BarcodeScanner.toggleFlashlight();
-                          break;
-                        case CameraActions.stopScanner:
-                          BarcodeScanner.stopScanner();
-                          break;
-                        case CameraActions.startScanner:
-                          BarcodeScanner.startScanner();
-                          break;
-                        case CameraActions.setOverlay:
-                          setState(() => withOverlay = !withOverlay);
-                          break;
-                      }
-                    },
-                    itemBuilder: (BuildContext context) =>
-                    <PopupMenuEntry<CameraActions>>[
-                      const PopupMenuItem<CameraActions>(
-                        value: CameraActions.flipCamera,
-                        child: Text('Flip camera'),
-                      ),
-                      const PopupMenuItem<CameraActions>(
-                        value: CameraActions.toggleFlashlight,
-                        child: Text('Toggle flashlight'),
-                      ),
-                      const PopupMenuItem<CameraActions>(
-                        value: CameraActions.stopScanner,
-                        child: Text('Stop scanner'),
-                      ),
-                      const PopupMenuItem<CameraActions>(
-                        value: CameraActions.startScanner,
-                        child: Text('Start scanner'),
-                      ),
-                      PopupMenuItem<CameraActions>(
-                        value: CameraActions.setOverlay,
-                        child:
-                        Text('${withOverlay ? 'Remove' : 'Add'} overlay'),
-                      ),
-                    ],
-                  ),
-                ]),
-            body: Builder(builder: (builderContext) {
-              Widget child = BarcodeScannerWidget(
-                scannerType: ScannerType.barcode,
-                onBarcodeDetected: (barcode) async {
-                  await showDialog(
-                      context: builderContext,
-                      builder: (dialogContext) {
-                        return Align(
-                            alignment: Alignment.center,
-                            child: Card(
-                                margin: const EdgeInsets.all(24),
-                                child: Container(
-                                    padding: const EdgeInsets.all(16),
-                                    child: Column(
-                                        mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          Text('barcode : ${barcode.value}'),
-                                          Text('format : ${barcode.format.name}'),
-                                          ElevatedButton(
-                                              onPressed: () =>
-                                                  Navigator.pop(dialogContext),
-                                              child: const Text('Close dialog'))
-                                        ]))));
-                      });
-                },
-                onTextDetected: (String text) async {
-                  await showDialog(
-                      context: builderContext,
-                      builder: (dialogContext) {
-                        return Align(
-                            alignment: Alignment.center,
-                            child: Card(
-                                margin: const EdgeInsets.all(24),
-                                child: Container(
-                                    padding: const EdgeInsets.all(16),
-                                    child: Column(
-                                        mainAxisSize: MainAxisSize.min,
-                                        children: [
-                                          Text('text : \n$text'),
-                                          ElevatedButton(
-                                              onPressed: () =>
-                                                  Navigator.pop(dialogContext),
-                                              child: const Text('Close dialog'))
-                                        ]))));
-                      });
-                },
-                onError: (dynamic error) {
-                  debugPrint('$error');
-                },
-              );
+    return MaterialApp(home: Builder(builder: (builderContext) {
+      return MyDemoApp();
+    }));
+  }
+}
 
-              if (withOverlay) {
-                return buildWithOverlay(builderContext, child);
+class MyDemoApp extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _MyDemoAppState();
+}
+
+class _MyDemoAppState extends State<MyDemoApp> {
+  bool withOverlay = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(title: const Text('Scanner plugin example app'), actions: [
+          PopupMenuButton<CameraActions>(
+            onSelected: (CameraActions result) {
+              switch (result) {
+                case CameraActions.flipCamera:
+                  BarcodeScanner.flipCamera();
+                  break;
+                case CameraActions.toggleFlashlight:
+                  BarcodeScanner.toggleFlashlight();
+                  break;
+                case CameraActions.stopScanner:
+                  BarcodeScanner.stopScanner();
+                  break;
+                case CameraActions.startScanner:
+                  BarcodeScanner.startScanner();
+                  break;
+                case CameraActions.setOverlay:
+                  setState(() => withOverlay = !withOverlay);
+                  break;
+                case CameraActions.navigate:
+                  navigate();
+                  break;
               }
+            },
+            itemBuilder: (BuildContext context) => <PopupMenuEntry<CameraActions>>[
+              const PopupMenuItem<CameraActions>(
+                value: CameraActions.flipCamera,
+                child: Text('Flip camera'),
+              ),
+              const PopupMenuItem<CameraActions>(
+                value: CameraActions.toggleFlashlight,
+                child: Text('Toggle flashlight'),
+              ),
+              const PopupMenuItem<CameraActions>(
+                value: CameraActions.stopScanner,
+                child: Text('Stop scanner'),
+              ),
+              const PopupMenuItem<CameraActions>(
+                value: CameraActions.startScanner,
+                child: Text('Start scanner'),
+              ),
+              PopupMenuItem<CameraActions>(
+                value: CameraActions.setOverlay,
+                child: Text('${withOverlay ? 'Remove' : 'Add'} overlay'),
+              ),
+              const PopupMenuItem<CameraActions>(
+                value: CameraActions.navigate,
+                child: Text('Navigate push'),
+              ),
+            ],
+          ),
+        ]),
+        body: Builder(builder: (builderContext) {
+          Widget child = BarcodeScannerWidget(
+            scannerType: ScannerType.barcode,
+            onBarcodeDetected: (barcode) async {
+              await showDialog(
+                  context: builderContext,
+                  builder: (dialogContext) {
+                    return Align(
+                        alignment: Alignment.center,
+                        child: Card(
+                            margin: const EdgeInsets.all(24),
+                            child: Container(
+                                padding: const EdgeInsets.all(16),
+                                child: Column(mainAxisSize: MainAxisSize.min, children: [Text('barcode : ${barcode.value}'), Text('format : ${barcode.format.name}'), ElevatedButton(onPressed: () => Navigator.pop(dialogContext), child: const Text('Close dialog'))]))));
+                  });
+            },
+            onTextDetected: (String text) async {
+              await showDialog(
+                  context: builderContext,
+                  builder: (dialogContext) {
+                    return Align(
+                        alignment: Alignment.center,
+                        child: Card(
+                            margin: const EdgeInsets.all(24), child: Container(padding: const EdgeInsets.all(16), child: Column(mainAxisSize: MainAxisSize.min, children: [Text('text : \n$text'), ElevatedButton(onPressed: () => Navigator.pop(dialogContext), child: const Text('Close dialog'))]))));
+                  });
+            },
+            onError: (dynamic error) {
+              debugPrint('$error');
+            },
+          );
 
-              return child;
-            })));
+          if (withOverlay) {
+            return buildWithOverlay(builderContext, child);
+          }
+
+          return child;
+        }));
   }
 
   buildWithOverlay(BuildContext builderContext, Widget scannerWidget) {
     return Stack(children: [
       Positioned.fill(child: scannerWidget),
-      Align(
-          alignment: Alignment.center,
-          child: Divider(color: Colors.red[400], thickness: 0.8)),
-      Center(
-          child: Container(
-              margin: const EdgeInsets.symmetric(horizontal: 64),
-              width: double.infinity,
-              height: 200,
-              decoration: BoxDecoration(
-                  border: Border.all(color: Colors.white, width: 2),
-                  borderRadius: BorderRadius.circular(15)))),
+      Align(alignment: Alignment.center, child: Divider(color: Colors.red[400], thickness: 0.8)),
+      Center(child: Container(margin: const EdgeInsets.symmetric(horizontal: 64), width: double.infinity, height: 200, decoration: BoxDecoration(border: Border.all(color: Colors.white, width: 2), borderRadius: BorderRadius.circular(15)))),
       Positioned(
           top: 16,
           right: 16,
           child: ElevatedButton(
-              style: ButtonStyle(
-                  backgroundColor: MaterialStateProperty.all(Colors.purple),
-                  foregroundColor: MaterialStateProperty.all(Colors.white),
-                  shape: MaterialStateProperty.all(const CircleBorder()),
-                  padding: MaterialStateProperty.all(const EdgeInsets.all(8))),
+              style: ButtonStyle(backgroundColor: MaterialStateProperty.all(Colors.purple), foregroundColor: MaterialStateProperty.all(Colors.white), shape: MaterialStateProperty.all(const CircleBorder()), padding: MaterialStateProperty.all(const EdgeInsets.all(8))),
               onPressed: () {
-                ScaffoldMessenger.of(builderContext).showSnackBar(
-                    const SnackBar(content: Text('Icon button pressed')));
+                ScaffoldMessenger.of(builderContext).showSnackBar(const SnackBar(content: Text('Icon button pressed')));
               },
               child: const Icon(Icons.refresh, size: 32))),
     ]);
+  }
+
+  navigate() {
+    Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) {
+      return Scaffold(
+          appBar: AppBar(
+            title: const Text('Navigate test view'),
+          ),
+          body: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const SizedBox(
+                width: double.infinity,
+              ),
+              const Text('Press back button'),
+              ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => MyDemoApp()));
+                  },
+                  child: const Text('Back'))
+            ],
+          ));
+    }));
   }
 }

--- a/ios/Classes/BarcodeScannerController.swift
+++ b/ios/Classes/BarcodeScannerController.swift
@@ -68,6 +68,9 @@ class BarcodeScannerController: UIViewController, AVCaptureMetadataOutputObjects
         case "flipCamera":
             switchCamera()
             result(nil)
+        case "closeCamera":
+            close()
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -125,6 +128,16 @@ class BarcodeScannerController: UIViewController, AVCaptureMetadataOutputObjects
             // If any error occurs, simply print it out and don't continue any more.
             print(error)
             return
+        }
+    }
+
+    func close() {
+        for input in captureSession.inputs {
+            captureSession.removeInput(input)
+        }
+
+        for output in captureSession.outputs {
+            captureSession.removeOutput(output)
         }
     }
     

--- a/lib/barcode_scanner.widget.dart
+++ b/lib/barcode_scanner.widget.dart
@@ -38,16 +38,9 @@ class BarcodeScannerWidget extends StatefulWidget {
   final Function(dynamic error) onError;
 
   const BarcodeScannerWidget(
-      {Key? key,
-        this.cameraSelector = CameraSelector.back,
-        this.startScanning = true,
-        this.stopScanOnBarcodeDetected = true,
-        this.orientation = CameraOrientation.portrait,
-        this.scannerType = ScannerType.barcode,
-        this.onBarcodeDetected,
-        this.onTextDetected,
-        required this.onError})
-      : assert(onBarcodeDetected != null || onTextDetected != null), super(key: key);
+      {Key? key, this.cameraSelector = CameraSelector.back, this.startScanning = true, this.stopScanOnBarcodeDetected = true, this.orientation = CameraOrientation.portrait, this.scannerType = ScannerType.barcode, this.onBarcodeDetected, this.onTextDetected, required this.onError})
+      : assert(onBarcodeDetected != null || onTextDetected != null),
+        super(key: key);
 
   @override
   State<BarcodeScannerWidget> createState() => _BarcodeScannerWidgetState();
@@ -55,8 +48,7 @@ class BarcodeScannerWidget extends StatefulWidget {
 
 class _BarcodeScannerWidgetState extends State<BarcodeScannerWidget> {
   static const String platformViewChannel = 'be.freedelity/native_scanner/view';
-  static const EventChannel eventChannel =
-  EventChannel('be.freedelity/native_scanner/imageStream');
+  static const EventChannel eventChannel = EventChannel('be.freedelity/native_scanner/imageStream');
 
   late Map<String, dynamic> creationParams;
   late StreamSubscription eventSubscription;
@@ -99,7 +91,11 @@ class _BarcodeScannerWidgetState extends State<BarcodeScannerWidget> {
 
   @override
   void dispose() {
-    eventSubscription.cancel();
+    try {
+      eventSubscription.cancel();
+    } on PlatformException catch (e) {
+      debugPrint("Intercept event subscription cancel exception on scanner disposed without stream initialized yet : $e");
+    }
     BarcodeScanner.closeCamera();
     super.dispose();
   }
@@ -107,11 +103,7 @@ class _BarcodeScannerWidgetState extends State<BarcodeScannerWidget> {
   @override
   Widget build(BuildContext context) {
     if (Platform.isIOS) {
-      return UiKitView(
-          viewType: platformViewChannel,
-          layoutDirection: TextDirection.ltr,
-          creationParams: creationParams,
-          creationParamsCodec: const StandardMessageCodec());
+      return UiKitView(viewType: platformViewChannel, layoutDirection: TextDirection.ltr, creationParams: creationParams, creationParamsCodec: const StandardMessageCodec());
     }
 
     return Stack(children: [
@@ -120,8 +112,7 @@ class _BarcodeScannerWidgetState extends State<BarcodeScannerWidget> {
           surfaceFactory: (context, controller) {
             return AndroidViewSurface(
               controller: controller as AndroidViewController,
-              gestureRecognizers: const <Factory<
-                  OneSequenceGestureRecognizer>>{},
+              gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
               hitTestBehavior: PlatformViewHitTestBehavior.opaque,
             );
           },
@@ -137,8 +128,7 @@ class _BarcodeScannerWidgetState extends State<BarcodeScannerWidget> {
                 })
               ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated);
           }),
-      const Positioned.fill(
-          child: ModalBarrier(dismissible: false, color: Colors.transparent))
+      const Positioned.fill(child: ModalBarrier(dismissible: false, color: Colors.transparent))
     ]);
   }
 }


### PR DESCRIPTION
Since e555e5b919d8c3465c40d4a76bd130c24fd1dfa9 we have the `closeCamera` channel method which is only implemented for Android. I clean inputs and ouputs of the `AVCaptureSession` on iOS.

Fixes #22 