### PR TITLE
Fix multiple bugs across Android and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.13
+- iOS : Support Flutter 3.35+ and UIScene (3.41+)
+- Fix : Android double camera initialization on startup
+- Fix : Android MRZ bitmap cropping crash with out-of-bounds coordinates
+- Fix : Android exception handler crash on non-CameraAccessException
+- Fix : iOS camera selector parameter was ignored
+- Fix : iOS force-unwrap crash in barcode metadata delegate
+- Fix : iOS double device lock in torch toggle
+- Fix : Dart widget assertion now accepts MRZ-only usage
+- Sync podspec version
+
 ## 1.0.12
 - Compatibility with Android 16Ko Page size support
 - Upgrade gradle version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Flutter plugin (`native_barcode_scanner`) providing real-time barcode, text, and MRZ scanning using native platform APIs. Published on pub.dev by Freedelity.
+
+- **Android:** Google ML Kit (barcode + text recognition) + CameraX
+- **iOS:** AVFoundation (native metadata output, no external SDKs)
+- **Text/MRZ scanning is Android-only** — iOS only supports barcode detection
+
+## Common Commands
+
+```bash
+# Analyze Dart code
+cd example && flutter analyze
+
+# Run example app (requires connected device/emulator)
+cd example && flutter run
+
+# Dry-run publish check
+flutter pub publish --dry-run
+
+# Build Android AAR
+cd example && flutter build apk
+
+# Build iOS (requires macOS)
+cd example && flutter build ios --no-codesign
+```
+
+There are no unit tests in this project.
+
+## Architecture
+
+### Three-Channel Bridge Pattern
+
+The plugin uses three Flutter platform channels for Dart ↔ native communication:
+
+| Channel | Type | ID | Purpose |
+|---------|------|----|---------|
+| Method | `MethodChannel` | `be.freedelity/native_scanner/method` | Imperative commands (toggleTorch, flipCamera, stopScanner, startScanner, closeCamera) |
+| Event | `EventChannel` | `be.freedelity/native_scanner/imageStream` | Streaming detection results (barcode, text, MRZ) + MRZ progress |
+| View | PlatformView | `be.freedelity/native_scanner/view` | Native camera preview embedding (avoids frame copying overhead) |
+
+### Dart Layer (lib/)
+
+- `barcode_scanner.dart` — Enums (`BarcodeFormat`, `ScannerType`, `CameraSelector`, `CameraOrientation`), `Barcode` model, `BarcodeScanner` static methods for camera control
+- `barcode_scanner.widget.dart` — `BarcodeScannerWidget` using `PlatformViewLink`/`AndroidViewSurface` (Android) and `UiKitView` (iOS)
+
+### Android Native (android/src/main/kotlin/be/freedelity/barcode_scanner/)
+
+Four-class architecture mirroring Flutter's platform view pattern:
+- `BarcodeScannerPlugin` — FlutterPlugin + ActivityAware entry point
+- `BarcodeScannerViewFactory` — Creates platform views
+- `BarcodeScannerView` — PlatformView wrapper, handles camera permissions
+- `BarcodeScannerController` — Core logic: CameraX lifecycle, ML Kit image analysis, frame debouncing (2s barcode, 500ms text, 100ms MRZ), autofocus configuration
+
+Utilities:
+- `util/MrzUtil.kt` — MRZ parsing for TD1 (3×30), TD2 (2×36), and passport (2×44) formats with checksum validation
+- `util/BarcodeScannerUtil.kt` — YUV_420_888 → ARGB_8888 bitmap conversion (integer-only, no floats)
+
+### iOS Native (ios/Classes/)
+
+Same four-class pattern, Swift implementation:
+- `BarcodeScannerPlugin.swift` — FlutterPlugin entry point
+- `BarcodeScannerViewFactory.swift` — Creates platform views
+- `BarcodeScannerView.swift` — FlutterPlatformView wrapper, permission handling
+- `BarcodeScannerController.swift` — AVCaptureSession + AVCaptureMetadataOutput for barcode detection
+
+### Platform Feature Parity
+
+| Feature | Android | iOS |
+|---------|---------|-----|
+| Barcode scanning | 11 formats (incl. Codabar, UPC-A) | 9 formats (no Codabar, no UPC-A) |
+| Text recognition | Yes (ML Kit) | No |
+| MRZ scanning | Yes (ML Kit + MrzUtil) | No |
+| Camera orientation param | Ignored (auto-detects) | Required |
+
+### Event Message Formats
+
+Barcode: `{"barcode": String, "format": int}` — format maps to `BarcodeFormat` enum index (0-10)
+Text: `{"text": String}`
+MRZ: `{"mrz": String, "img": Uint8List}` (PNG bytes of cropped document)
+Progress: `{"progress": int}` (MRZ only: 5, 25, 75, 90)
+
+## Build Configuration
+
+- **Android:** compileSdk 35, minSdk 21, Kotlin 1.7.22, Gradle plugin 8.1.1
+- **iOS:** deployment target 11.0, Swift 5.0
+- **Dart/Flutter SDK:** >=3.0.0 <4.0.0

--- a/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerController.kt
+++ b/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerController.kt
@@ -235,7 +235,7 @@ class BarcodeScannerController(private val activity: Activity, messenger: Binary
             result.error("CameraAccess", exception.message, null)
             return
         }
-        throw (exception as RuntimeException)
+        result.error("native_scanner_failed", exception.message, null)
     }
 
     private fun configureAutofocus() {
@@ -421,19 +421,13 @@ class BarcodeScannerController(private val activity: Activity, messenger: Binary
 
                                         Log.i("native_scanner", "Extract MRZ done with result $mrz")
 
-                                        var x = points!![0].x
-                                        var y = points!![0].y
-                                        var width = points!![1].x - points!![0].x
-                                        var height = points!![2].y - points!![0].y
+                                        val bmpW = mrzBitmap!!.width
+                                        val bmpH = mrzBitmap!!.height
 
-                                        if (width > mrzBitmap!!.width) {
-                                            x = 0
-                                            width = mrzBitmap!!.width
-                                        }
-                                        if (height > mrzBitmap!!.height) {
-                                            y = 0
-                                            height = mrzBitmap!!.height
-                                        }
+                                        var x = points!![0].x.coerceIn(0, bmpW - 1)
+                                        var y = points!![0].y.coerceIn(0, bmpH - 1)
+                                        var width = (points!![1].x - points!![0].x).coerceIn(1, bmpW - x)
+                                        var height = (points!![2].y - points!![0].y).coerceIn(1, bmpH - y)
 
                                         val croppedBitmap = Bitmap.createBitmap(
                                             mrzBitmap!!,

--- a/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerPlugin.kt
+++ b/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerPlugin.kt
@@ -51,7 +51,7 @@ class BarcodeScannerPlugin: FlutterPlugin, ActivityAware {
 
     flutterPluginBinding
       .platformViewRegistry
-      .registerViewFactory(platformViewChannel, BarcodeScannerViewFactory(activity, barcodeScannerController!!))
+      .registerViewFactory(platformViewChannel, BarcodeScannerViewFactory(activity, barcodeScannerController!!, binding))
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {onAttachedToActivity(binding)}

--- a/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerView.kt
+++ b/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerView.kt
@@ -11,20 +11,27 @@ import android.view.View
 import androidx.camera.view.PreviewView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.platform.PlatformView
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-internal class BarcodeScannerView(activity: Activity, barcodeScannerController: BarcodeScannerController, context: Context, creationParams: Map<String?, Any?>?) : PlatformView {
+internal class BarcodeScannerView(activity: Activity, barcodeScannerController: BarcodeScannerController, context: Context, creationParams: Map<String?, Any?>?, activityBinding: ActivityPluginBinding) : PlatformView, PluginRegistry.RequestPermissionsResultListener {
 
     private val cameraExecutor: ExecutorService = Executors.newSingleThreadExecutor()
     private val previewView: PreviewView = PreviewView(context)
+    private val activityBinding: ActivityPluginBinding = activityBinding
+    private val controller: BarcodeScannerController = barcodeScannerController
+    private val params: Map<String?, Any?>? = creationParams
+    private val viewContext: Context = context
 
     override fun getView(): View {
         return previewView
     }
 
     override fun dispose() {
+        activityBinding.removeRequestPermissionsResultListener(this)
         cameraExecutor.shutdown()
     }
 
@@ -32,8 +39,20 @@ internal class BarcodeScannerView(activity: Activity, barcodeScannerController: 
         if( allPermissionsGranted(context) ) {
             barcodeScannerController.startCamera(creationParams, context, previewView, cameraExecutor)
         } else {
+            activityBinding.addRequestPermissionsResultListener(this)
             ActivityCompat.requestPermissions(activity, REQUIRED_PERMISSIONS, REQUEST_CODE_PERMISSIONS)
         }
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray): Boolean {
+        if (requestCode == REQUEST_CODE_PERMISSIONS) {
+            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                controller.startCamera(params, viewContext, previewView, cameraExecutor)
+            }
+            activityBinding.removeRequestPermissionsResultListener(this)
+            return true
+        }
+        return false
     }
 
     companion object {

--- a/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerView.kt
+++ b/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerView.kt
@@ -29,14 +29,11 @@ internal class BarcodeScannerView(activity: Activity, barcodeScannerController: 
     }
 
     init {
-
         if( allPermissionsGranted(context) ) {
             barcodeScannerController.startCamera(creationParams, context, previewView, cameraExecutor)
         } else {
             ActivityCompat.requestPermissions(activity, REQUIRED_PERMISSIONS, REQUEST_CODE_PERMISSIONS)
         }
-
-        barcodeScannerController.startCamera(creationParams, context, previewView, cameraExecutor)
     }
 
     companion object {

--- a/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerViewFactory.kt
+++ b/android/src/main/kotlin/be/freedelity/barcode_scanner/BarcodeScannerViewFactory.kt
@@ -5,13 +5,14 @@ package be.freedelity.barcode_scanner
 
 import android.app.Activity
 import android.content.Context
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
 
-class BarcodeScannerViewFactory(private val activity: Activity, private val barcodeScannerController: BarcodeScannerController) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+class BarcodeScannerViewFactory(private val activity: Activity, private val barcodeScannerController: BarcodeScannerController, private val activityBinding: ActivityPluginBinding) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
 
     override fun create(context: Context?, viewId: Int, args: Any?): PlatformView {
-        return BarcodeScannerView(activity, barcodeScannerController, context!!, args as Map<String?, Any?>?)
+        return BarcodeScannerView(activity, barcodeScannerController, context!!, args as Map<String?, Any?>?, activityBinding)
     }
 }

--- a/ios/Classes/BarcodeScannerController.swift
+++ b/ios/Classes/BarcodeScannerController.swift
@@ -209,14 +209,13 @@ class BarcodeScannerController: UIViewController, AVCaptureMetadataOutputObjects
 
         do {
             try device.lockForConfiguration()
+            defer { device.unlockForConfiguration() }
 
             if (mode == .off) {
                 device.torchMode = AVCaptureDevice.TorchMode.off
             } else {
                 try device.setTorchModeOn(level: 1.0)
             }
-
-            device.unlockForConfiguration()
         } catch {
             print(error)
         }

--- a/ios/Classes/BarcodeScannerController.swift
+++ b/ios/Classes/BarcodeScannerController.swift
@@ -84,7 +84,7 @@ class BarcodeScannerController: UIViewController, AVCaptureMetadataOutputObjects
             
             let cameraPosition: AVCaptureDevice.Position = (self.selector == "front") ? .front : .back
             let deviceDiscoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: AVMediaType.video, position: cameraPosition)
-            // Get the back-facing camera for capturing videos
+            // Get the camera device matching the selected position
             guard let captureDevice = deviceDiscoverySession.devices.first else {
                 barcodeStream?(FlutterError(code: "native_scanner_failed", message: "Failed to get the camera device", details: nil))
                 return
@@ -194,35 +194,31 @@ class BarcodeScannerController: UIViewController, AVCaptureMetadataOutputObjects
         guard let device = getCaptureDeviceFromCurrentSession(session: captureSession) else {
             return
         }
-        
-        do {
-            try device.lockForConfiguration()
-            
-            if (device.torchMode == AVCaptureDevice.TorchMode.off) {
-                setFlashStatus(device: device, mode: .on)
-            } else {
-                setFlashStatus(device: device, mode: .off)
-            }
-            
-            device.unlockForConfiguration()
-        } catch {
-            print(error)
+
+        if (device.torchMode == AVCaptureDevice.TorchMode.off) {
+            setFlashStatus(device: device, mode: .on)
+        } else {
+            setFlashStatus(device: device, mode: .off)
         }
     }
-    
+
     private func setFlashStatus(device: AVCaptureDevice, mode: AVCaptureDevice.TorchMode) {
         guard device.hasTorch else {
             return
         }
 
-        if (mode == .off) {
-            device.torchMode = AVCaptureDevice.TorchMode.off
-        } else {
-            do {
+        do {
+            try device.lockForConfiguration()
+
+            if (mode == .off) {
+                device.torchMode = AVCaptureDevice.TorchMode.off
+            } else {
                 try device.setTorchModeOn(level: 1.0)
-            } catch {
-                print(error)
             }
+
+            device.unlockForConfiguration()
+        } catch {
+            print(error)
         }
     }
     

--- a/ios/Classes/BarcodeScannerController.swift
+++ b/ios/Classes/BarcodeScannerController.swift
@@ -41,6 +41,7 @@ class BarcodeScannerController: UIViewController, AVCaptureMetadataOutputObjects
     }
     
     override public func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         captureSession.stopRunning()
     }
     
@@ -81,7 +82,8 @@ class BarcodeScannerController: UIViewController, AVCaptureMetadataOutputObjects
         
         do {
             
-            let deviceDiscoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: AVMediaType.video, position: .back)
+            let cameraPosition: AVCaptureDevice.Position = (self.selector == "front") ? .front : .back
+            let deviceDiscoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: AVMediaType.video, position: cameraPosition)
             // Get the back-facing camera for capturing videos
             guard let captureDevice = deviceDiscoverySession.devices.first else {
                 barcodeStream?(FlutterError(code: "native_scanner_failed", message: "Failed to get the camera device", details: nil))
@@ -105,7 +107,7 @@ class BarcodeScannerController: UIViewController, AVCaptureMetadataOutputObjects
             
             videoPreviewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
             videoPreviewLayer?.videoGravity = .resizeAspectFill
-            if (self.orientation == "portrait" || self.orientation == nil) {
+            if (self.orientation == "portrait") {
                 videoPreviewLayer?.connection?.videoOrientation = .portrait
             } else if (self.orientation == "landscapeLeft") {
                 videoPreviewLayer?.connection?.videoOrientation = .landscapeLeft
@@ -150,7 +152,9 @@ class BarcodeScannerController: UIViewController, AVCaptureMetadataOutputObjects
         }
 
         // Get the metadata object.
-        let metadataObj = metadataObjects[0] as! AVMetadataMachineReadableCodeObject
+        guard let metadataObj = metadataObjects[0] as? AVMetadataMachineReadableCodeObject else {
+            return
+        }
         if supportedCodeTypes.contains(metadataObj.type) {
             if metadataObj.stringValue != nil {
                 barcodeStream?(["barcode": metadataObj.stringValue!, "format": convertBarcodeType(type: metadataObj.type)])
@@ -210,24 +214,15 @@ class BarcodeScannerController: UIViewController, AVCaptureMetadataOutputObjects
         guard device.hasTorch else {
             return
         }
-        
-        do {
-            try device.lockForConfiguration()
-            
-            if (mode == .off) {
-                device.torchMode = AVCaptureDevice.TorchMode.off
-            } else {
-                // Treat .auto & .on equally.
-                do {
-                    try device.setTorchModeOn(level: 1.0)
-                } catch {
-                    print(error)
-                }
+
+        if (mode == .off) {
+            device.torchMode = AVCaptureDevice.TorchMode.off
+        } else {
+            do {
+                try device.setTorchModeOn(level: 1.0)
+            } catch {
+                print(error)
             }
-            
-            device.unlockForConfiguration()
-        } catch {
-            print(error)
         }
     }
     

--- a/ios/native_barcode_scanner.podspec
+++ b/ios/native_barcode_scanner.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'native_barcode_scanner'
-  s.version          = '1.0.11'
+  s.version          = '1.0.13'
   s.summary          = 'Barcode scanner plugin'
   s.description      = <<-DESC
 Barcode scanner plugin

--- a/lib/barcode_scanner.widget.dart
+++ b/lib/barcode_scanner.widget.dart
@@ -54,7 +54,7 @@ class BarcodeScannerWidget extends StatefulWidget {
         this.onScanProgress,
         required this.onError,
       })
-      : assert(onBarcodeDetected != null || onTextDetected != null),
+      : assert(onBarcodeDetected != null || onTextDetected != null || onMrzDetected != null),
         super(key: key);
 
   @override


### PR DESCRIPTION
## Summary
- **Android**: Remove duplicate `startCamera` call + add permission result callback for first-install flow
- **Android**: Fix MRZ bitmap cropping crash with out-of-bounds coordinates (coerceIn)
- **Android**: Fix exception handler crash on non-CameraAccessException
- **iOS**: Use camera selector parameter in device discovery (was ignored)
- **iOS**: Safe cast in metadata output delegate (prevent force-unwrap crash)
- **iOS**: Fix torch toggle double device lock + guarantee unlock with defer
- **iOS**: Add missing `super.viewDidDisappear` call
- **Dart**: Widget assertion now accepts MRZ-only usage
- Sync podspec version to 1.0.13, add CHANGELOG entry

## Test plan
- [x] `flutter analyze` passes (only pre-existing info lint in example app)
- [x] Tested on physical Android device (Samsung Galaxy S9+, API 29)
- [x] 4 rounds of code review with all issues resolved